### PR TITLE
共有先のサーバー名を設定する機能を追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,19 @@
 			"js":["script.js"]
 		}
 	],
+	"action": {
+		"default_icon": {
+			"16": "icons/16.png",
+			"48": "icons/48.png",
+			"128": "icons/128.png"
+		},
+		"default_title": "共有先のサーバー名の設定",
+		"default_popup": "options.html"
+	},
+	"options_ui": {
+		"page": "options.html"
+	},
+	"permissions": ["storage"],
 	"author":"Alkappa/alpaca-honke",
 	"homepage_url":"https://github.com/alpaca-honke/twishare-to-io/"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="content-type" content="text/html;charset=utf-8" />
+	</head>
+	<body>
+		<div>
+			<p>共有先のサーバー名</p>
+			<p>(URLのhttps://の後に続く文字列)</p>
+			<input type="textbox" id="instance_name" />
+			<button id="save_button">保存</button>
+		</div>
+
+		<script src="options.js"></script>
+	</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,24 @@
+function Save() {
+    const instance_name =
+        document.getElementById("instance_name").value || "Misskey.io";
+    // 文頭のhttps://と/が出た以降から文末までの文字 がある場合、その文字列を無視して保存する
+    chrome.storage.sync.set(
+        {
+            instance_name: instance_name
+                .replace(/^https?:\/\//, "")
+                .replace(/\/(.*)$/, ""),
+        },
+        function () {}
+    );
+}
+
+function Load() {
+    chrome.storage.sync.get("instance_name", function (items) {
+        document.getElementById("instance_name").value =
+            items.instance_name || "Misskey.io";
+    });
+}
+
+document.addEventListener("DOMContentLoaded", Load);
+
+document.getElementById("save_button").addEventListener("click", Save);

--- a/script.js
+++ b/script.js
@@ -1,44 +1,49 @@
-const result = window.confirm('Twitter へのシェアリンクを確認しました。この内容を Misskey.io にシェアしますか？(拡張機能 Twishare to io より)')
+chrome.storage.sync.get("instance_name", function (items) {
+	const instance_name = items.instance_name || "Misskey.io";
 
-if (result) {
-	let tw_url = new URL(window.location.href);
-	let params = tw_url.searchParams;
-	let text;
-	let url;
-	let hashtags;
-	let share_text;
-	let share_url
+	const result = window.confirm(
+		`Twitter へのシェアリンクを確認しました。この内容を ${instance_name} にシェアしますか？(拡張機能 Twishare to io より)`
+	);
 
-	if ( params.has('text') ) {
-		text = params.get('text');
-	}
-	if ( params.has('url') ) {
-		url = params.get('url');
-	}
-	if ( params.has('hashtags') ) {
-		hashtags = params.get('hashtags');
-	}
+	if (result) {
+		let tw_url = new URL(window.location.href);
+		let params = tw_url.searchParams;
+		let text;
+		let url;
+		let hashtags;
+		let share_text;
+		let share_url;
 
-	let io_url = new URL("https://misskey.io/share");
-
-	if (text){
-		if (hashtags){
-			tagged_hashtags = '#' + hashtags.replace(/\,/g, ' #');
-			share_text = text + '\n' + tagged_hashtags;
-		}else{
-			share_text = text;
+		if (params.has("text")) {
+			text = params.get("text");
 		}
-	}else if (hashtags){
-		tagged_hashtags = ' #' + hashtags.replace(/\,/g, ' #');
-		share_text = encodeURIComponent(tagged_hashtags);
-	}
-	io_url.searchParams.set('text',share_text);
-	
-	if (url) {
-		share_url = url;
-		io_url.searchParams.set('url',share_url);
-	}
-	
+		if (params.has("url")) {
+			url = params.get("url");
+		}
+		if (params.has("hashtags")) {
+			hashtags = params.get("hashtags");
+		}
 
-	location.href = io_url;
-}
+		let instance_url = new URL(`https://${instance_name}/share`);
+
+		if (text) {
+			if (hashtags) {
+				tagged_hashtags = "#" + hashtags.replace(/\,/g, " #");
+				share_text = text + "\n" + tagged_hashtags;
+			} else {
+				share_text = text;
+			}
+		} else if (hashtags) {
+			tagged_hashtags = " #" + hashtags.replace(/\,/g, " #");
+			share_text = encodeURIComponent(tagged_hashtags);
+		}
+		instance_url.searchParams.set("text", share_text);
+
+		if (url) {
+			share_url = url;
+			instance_url.searchParams.set("url", share_url);
+		}
+
+		location.href = instance_url;
+	}
+});


### PR DESCRIPTION
共有先のサーバー名を設定する機能を追加しました。

ブラウザ右上に表示されるアイコン または 拡張機能のオプションにて設定を行う事が出来ます。

![image](https://github.com/alpaca-honke/twishare-to-io/assets/65014664/81f38315-ba80-488e-9c66-a4ac29faeb99)

![image](https://github.com/alpaca-honke/twishare-to-io/assets/65014664/0baf08f1-46e1-41d2-832e-a802f0a0825f)

![image](https://github.com/alpaca-honke/twishare-to-io/assets/65014664/b9ad7b27-be7d-4ff4-9c23-da2fd37e620f)
