### PR TITLE
location.hrefの代入修正

### DIFF
--- a/on_twitter_intent.js
+++ b/on_twitter_intent.js
@@ -45,6 +45,6 @@ chrome.storage.sync.get("instance_name", function (items) {
 			instance_url.searchParams.set("url", share_url);
 		}
 
-		location.href = instance_url;
+		location.href = instance_url.href;
 	}
 });


### PR DESCRIPTION
`instance_url` (URLオブジェクト) を文字列に変換してから `location.href` に代入するようにします。