### PR TITLE
設定: 共有先サーバー名のinputのtype修正

### DIFF
--- a/options.html
+++ b/options.html
@@ -10,7 +10,7 @@
 			<p>共有先のサーバー名を設定してください。</p>
 			<p>(URLのhttps://の後に続く文字列)</p>
 			<p>デフォルト値はMisskey.ioです</p>
-			<input type="textbox" id="instance_name" />
+			<input type="text" id="instance_name" />
 			<button id="save_button">保存</button>
 			<p id="save_status"></p>
 		</div>


### PR DESCRIPTION
https://developer.mozilla.org/ja/docs/Web/HTML/Element/input#input_%E3%81%AE%E5%9E%8B

共有先サーバー名のinputのtypeに `textbox` という正しくないtypeが指定されているので `text` に修正します。