### PR TITLE
全画面表示時に画面右下のシェアボタンを非表示にする機能の追加

### DIFF
--- a/js_and_css/allpages.js
+++ b/js_and_css/allpages.js
@@ -12,6 +12,7 @@ async function setButtonIfNeeded() {
 	const whether_set_button = await whetherSetButton();
 	if (whether_set_button) {
 		setButton();
+		hideButtonOnFullscreen();
 	}
 }
 
@@ -91,5 +92,16 @@ function setButton(){
 			instance_url.searchParams.set("text",share_text);
 			window.open(instance_url.href);
 		});
+	});
+}
+
+function hideButtonOnFullscreen(){
+	document.addEventListener('fullscreenchange', () => {
+		const button = document.querySelector('#_twishare_to_misskey_share');
+		if (button == null){ return; }
+
+		const toFullscreen = document.fullscreenElement;
+		if (toFullscreen) { button.classList.add('hidden'); }
+		else { button.classList.remove('hidden'); }
 	});
 }


### PR DESCRIPTION
機能を追加しました。
フルスクリーンの切り替えイベントにフックしてボタンのhidden属性を切り替えます。

以下で動作確認をしました。
OS: Windows11
ブラウザ: Chrome
サイト: Twitch, Youtube

Pull requestが不慣れなので間違いがあるかもしれません。