### PR TITLE
Windows用のswitch_browserを追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,5 +74,6 @@ switch_browser.shというシェルスクリプトがリポジトリルートに
 |- CONTRIBUTING.md この文書
 |- LICENSE MITライセンス
 |- README.md 説明
-|- switch_browser.sh マニフェストファイルを設置するシェルスクリプト
+|- switch_browser.bat マニフェストファイルを設置するシェルスクリプト(Windows用)
+|- switch_browser.sh マニフェストファイルを設置するシェルスクリプト(Linux用)
 ```

--- a/switch_browser.bat
+++ b/switch_browser.bat
@@ -1,0 +1,26 @@
+@echo off
+
+@REM 「～ is not recognized as an internal or external command」対策のため日本語の行末には「 」をつけること 
+@REM 文字コード切り替え win10はSJISが標準なのでUTF-8に切り替え 
+@REM □で文字化けする場合は日本語表示できるフォントに切り替えること
+chcp 65001
+
+set rootDirPath=%~dp0
+set rootManifestPath=%rootDirPath%manifest.json
+
+IF "%1"=="" (
+    IF exist %rootManifestPath% (
+        del %rootManifestPath%
+    )
+) ELSE (
+    IF "%1"=="chrome" (
+        copy /y %rootDirPath%chrome\manifest.json %rootManifestPath%
+    ) ELSE IF "%1"=="webext" (
+        copy /y %rootDirPath%webext\manifest.json %rootManifestPath%
+    ) ELSE (
+        echo 引数に無効な値が指定されています 
+        echo 引数を指定しなければリポジトリのルートからmanifest.jsonを削除します 
+        echo chromeを指定すればChrome向けのマニフェストが設定されます 
+        echo webextを指定すればWebExtensions向けのマニフェストが設定されます 
+    )
+)


### PR DESCRIPTION
Issues #22 
switch_browser.shをbatファイルとして書き直しました。

基本動作は同じです。

日本語の標準出力でエラーが出る場合があるので対策として文末に「 」を追加しました。
Win10用に文字コードの変更を追加しました。

以下の環境で動作確認をしました。
OS: Windows 10
標準文字コード: SJIS
コンソール: VSCode内のPowershell、Powershell、コマンドプロンプト